### PR TITLE
디테일 데이터 붙이기, 공식전, 일반전 구분 렌더링 구현 완료

### DIFF
--- a/cyphers-record-search/src/components/LineGraph.vue
+++ b/cyphers-record-search/src/components/LineGraph.vue
@@ -1,6 +1,6 @@
 <template>
     <LineChartGenerator
-        v-if="loaded"
+        v-if="chartData"
         :options="chartOptions"
         :data="chartData"
         :chart-id="chartId"
@@ -29,7 +29,7 @@ import {
   CategoryScale,
   PointElement
 } from 'chart.js'
-import axios from 'axios'
+// import axios from 'axios'
 
 ChartJS.register(
     Title,
@@ -42,6 +42,7 @@ ChartJS.register(
 )
 
 export default {
+
   name: 'LineChart',
   components: {
     LineChartGenerator
@@ -74,34 +75,14 @@ export default {
     plugins: {
       type: Array,
       default: () => []
-    }
+    },
+    chartData: {
+      type: Object,
+      required: true,
+    },
   },
   data() {
     return {
-      loaded: false,
-      chartData: {
-        labels: [
-          '08-19',
-          '08-20',
-          '08-21',
-          '08-22',
-          '08-23',
-          '08-24',
-          '08-25'
-        ],
-        datasets: [
-          {
-            label: '승수',
-            backgroundColor: '#f87979',
-            data: [0, 0, 0, 0, 0, 0, 0]
-          },
-          {
-            label: '패수',
-            backgroundColor: '#f87979',
-            data: [0, 0, 0, 0, 0, 0, 0]
-          },
-        ]
-      },
       chartOptions: {
         responsive: true,
         maintainAspectRatio: false
@@ -109,43 +90,13 @@ export default {
     }
   },
   created() {
-    this.fetchChartData();
+
   },
   methods: {
-    fetchChartData() {
-      axios.get(`/api/search/player/detail/${this.$route.params.nickname}`)
-        .then((response) => {
-          const detailData = response.data;
-          this.chartData.labels = this.generateDateLabels();
-
-          this.chartData.datasets[0].data = detailData.resultHistory.map(entry => entry.winCount);
-          this.chartData.datasets[1].data = detailData.resultHistory.map(entry => entry.loseCount);
-          this.loaded = true;
-
-        })
-        .catch((error) => {
-          alert("승패 데이터를 가져올 수 없습니다.", error);
-          console.log("chart error: ", error);
-        });
-    },
-    generateDateLabels() {
-      const today = new Date(); 
-      const dateLabels = [];
-
-      for (let i = 6; i >= 0; i--) {
-        const date = new Date(today);
-        date.setDate(today.getDate() - i);
-        const formattedDate = this.formatDate(date); 
-        dateLabels.push(formattedDate);
-      }
-
-      return dateLabels; 
-    },
-    formatDate(date) {
-      const month = String(date.getMonth() + 1).padStart(2, '0'); 
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${month}-${day}`; 
-    },
-  }
+    
+  },
+  mounted() {
+    
+  },
 }
 </script>

--- a/cyphers-record-search/src/components/PieGraph.vue
+++ b/cyphers-record-search/src/components/PieGraph.vue
@@ -13,17 +13,15 @@ export default {
   components: {
     Pie
   },
+  props: {
+    chartData: {
+      type : Object,
+      required: true,
+    }
+  },
   data() {
     return {
-      data: {
-        labels: ['탱커', '원거리딜러', '서포터', '근거리딜러'],
-        datasets: [
-          {
-            backgroundColor: ['#b7d7ef', '#f5d7ee', '#ffecb3', '#ef9a9a'],
-            data: [40, 20, 80, 10],
-          },
-        ],
-      },
+      data: this.chartData,
       options: {
         responsive: true,
         maintainAspectRatio: false,
@@ -34,22 +32,18 @@ export default {
         },
         layout: {
           padding: {
-            left: 100,   // 왼쪽 패딩
-            right: 100,  // 오른쪽 패딩
-            top: 20,    // 상단 패딩
-            bottom: 20  // 하단 패딩
+            left: 100,   
+            right: 100,  
+            top: 20,    
+            bottom: 20  
           }
         },
-        // 여기에 애니메이션 옵션을 추가
         animation: {
           duration: 1000, // 애니메이션 지속 시간
           easing: 'easeOutBounce', // 애니메이션의 easing 효과
           animateRotate: true, // 원의 회전 애니메이션 사용
           animateScale: false, // 원의 크기 변경 애니메이션 사용 여부
         },
-        chartOptions: {
-          responsive: true
-        }
       }
     }
   }

--- a/src/main/java/com/cyphers/game/RecordSearch/controller/search/SearchController.java
+++ b/src/main/java/com/cyphers/game/RecordSearch/controller/search/SearchController.java
@@ -63,8 +63,8 @@ public class SearchController {
     public void renewalDetail(@PathVariable("nickname") String nickname) throws Exception {
     	
 		IoSearchDetail detailSearchRating = searchService.renewalDetailSearch(nickname, CyphersGameType.RATING);
-		IoSearchDetail detailSearchNormal = searchService.renewalDetailSearch(nickname, CyphersGameType.NORMAL);
     	crsSearchService.upsertDetailSearch(detailSearchRating, CyphersGameType.RATING);
+		IoSearchDetail detailSearchNormal = searchService.renewalDetailSearch(nickname, CyphersGameType.NORMAL);
     	crsSearchService.upsertDetailSearch(detailSearchNormal, CyphersGameType.NORMAL);
     	
     }

--- a/src/main/java/com/cyphers/game/RecordSearch/service/search/CrsSearchService.java
+++ b/src/main/java/com/cyphers/game/RecordSearch/service/search/CrsSearchService.java
@@ -39,8 +39,8 @@ public class CrsSearchService {
 		
 		Optional<CrsDetailSearch> crsDetail = crsDetailSearchRepository.findByPlayerIdAndGameType(detailResponse.getPlayerId(), gameType);
 		
-		if (crsDetail.isPresent()) {
-			insertDetailSearch(detailResponse);
+		if (!crsDetail.isPresent()) {
+			insertDetailSearch(detailResponse, gameType);
 			return;
 		}
 
@@ -78,7 +78,7 @@ public class CrsSearchService {
 		List<CrsResultHistory> resultHistory = response.getResultHistory();
 		List<IoSearchDetailResultHistoryInfo> ioRPHistory = detailResponse.getResultHistory();
 		
-		for (int i = 0; i < mostCypherInfos.size(); i++) {
+		for (int i = 0; i < resultHistory.size(); i++) {
             CrsResultHistory crsResultHistory = resultHistory.get(i);
             IoSearchDetailResultHistoryInfo ioResultInfo = ioRPHistory.get(i);
             
@@ -107,10 +107,12 @@ public class CrsSearchService {
 		
 	}
 	
-	public void insertDetailSearch(IoSearchDetail detailResponse) {
+	public void insertDetailSearch(IoSearchDetail detailResponse, CyphersGameType gameType) {
 		
 		CrsDetailSearch response = CrsDetailSearch.builder()
 								.playerId(detailResponse.getPlayerId()) 
+								.nickname(detailResponse.getNickname())
+								.gameType(gameType)
 								.recentlyUpdatedDate(LocalDateTime.now())
 								.mostCypherInfos(null)
 								.tankerUseRate(detailResponse.getTankerUseRate())

--- a/src/main/java/com/cyphers/game/RecordSearch/service/search/SearchService.java
+++ b/src/main/java/com/cyphers/game/RecordSearch/service/search/SearchService.java
@@ -92,6 +92,7 @@ public class SearchService {
 
 		// pk가 될 플레이어ID
 		ioDetail.setPlayerId(myPlayerId);
+		ioDetail.setNickname(nickname);
 
 		List<CyphersMatchedInfo> cyMatchedInfoRows = getMatchedInfos(myPlayerId, gameType); // 각 기능에서 쓰일 리스트
 
@@ -112,11 +113,13 @@ public class SearchService {
 
 		// 모스트 사이퍼
 		ioDetail.setMostCypherInfos(Collections.emptyList());
+		log.info("idList 크기: "+idList.size());
 
 		if (cyMatchedInfoRows.size() != 0) {
 			List<IoSearchDetailMostCypherInfo> mostCypherRows = new ArrayList<>();
-
-			for (int i = 0; i < MOST_CYPHER_LENGTH; i++) {
+			
+			//만약 모스트 사이퍼에 선정할 캐릭터가 MOST_CYPHER_LENGTH보다 적다면 idList만큼만 생성
+			for (int i = 0; i < (idList.size() >= MOST_CYPHER_LENGTH ? MOST_CYPHER_LENGTH : idList.size()); i++) {
 				IoSearchDetailMostCypherInfo mostCypherInfo = new IoSearchDetailMostCypherInfo();
 				mostCypherInfo.setCharacterImage("https://img-api.neople.co.kr/cy/characters/"+idList.get(i)+"?zoom=3");
 				for (CyphersCharacterInfo characterInfo : cyCharacter.getRows()) {
@@ -514,7 +517,10 @@ public class SearchService {
 				gameType, ApiDate.NINETY_DAYS_AGO, ApiDate.NOW);
 		CyphersMatchingHistory cyMatchingHistory2 = cyApiService.searchMatchingHistory(playerId,
 				gameType, ApiDate.HALF_YEARS_AGO, ApiDate.NINETY_DAYS_AGO);
-
+		
+		log.info("매칭기록1: ", cyMatchingHistory1);
+		log.info("매칭기록2: ", cyMatchingHistory2);
+		
 		List<CyphersMatchedInfo> matchedInfos = new ArrayList<>();
 
 		for (CyphersMatchedInfo cyMatchedInfo1 : cyMatchingHistory1.getMatches().getRows()) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/crs?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
 
 # if you created tables, change create -> update 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
1. 디테일 데이터를 공식전, 일반전 따로 DB에 저장해서 버튼을 누를 때마다 해당 타입의 디테일 데이터를 가져오도록 구현
2. 게임기록도 버튼을 누르면 따로 공식전, 일반전 게임기록을 불러올 수 있도록 구현.
  → 공식전과 일반전의 API요청을 따로 해야하기 때문에 따로 통합하진 않고 구분해서 불러오도록만 구현.
3. 승패그래프 1주 → 2주로 변경, 최근 플레이한 캐릭터 디자인 부분 수정 하면 끝!